### PR TITLE
refactor: 네트워크 그래프 노드와 링크 컴포넌트

### DIFF
--- a/components/NetworkLinks.tsx
+++ b/components/NetworkLinks.tsx
@@ -1,0 +1,33 @@
+import { Link } from '@/types';
+import { select } from 'd3';
+import { useEffect, useRef } from 'react';
+
+type LinksProps = {
+  data: Link[];
+};
+
+type LinkProps = {
+  data: Link;
+};
+
+const NetworkLink = ({ data }: LinkProps) => {
+  const lineRef = useRef<SVGLineElement>(null);
+
+  useEffect(() => {
+    select(lineRef.current).data([data]);
+  }, [data]);
+
+  return <line ref={lineRef} className="link" strokeWidth="1" />;
+};
+
+const NetworkLinks = ({ data }: LinksProps = { data: [] }) => {
+  return (
+    <g stroke="#999" strokeOpacity="0.3">
+      {data?.map((link, index) => (
+        <NetworkLink key={index} data={link} />
+      ))}
+    </g>
+  );
+};
+
+export default NetworkLinks;

--- a/components/NetworkNodes.tsx
+++ b/components/NetworkNodes.tsx
@@ -1,0 +1,51 @@
+import { Node } from '@/types';
+import { fillCircleByValue, weighValueByMutiply } from '@/utils/chart';
+import { select } from 'd3';
+import { useEffect, useRef } from 'react';
+
+type NodesProps = {
+  data: Node[];
+};
+
+type NodeProps = {
+  data: Node;
+};
+
+const NetworkNode = ({ data }: NodeProps) => {
+  const circleRef = useRef<SVGCircleElement>(null);
+  const textRef = useRef<SVGTextElement>(null);
+
+  useEffect(() => {
+    select(circleRef.current)
+      .data([data])
+      .attr('r', (d) => weighValueByMutiply(d.value))
+      .attr('fill', (d) => fillCircleByValue(d.value));
+
+    select(textRef.current)
+      .data([data])
+      .text((d) => d.name)
+      .attr('dy', 6)
+      .style('text-anchor', 'middle');
+  }, [data]);
+
+  return (
+    <g>
+      <circle className="node" ref={circleRef}></circle>
+      <text className="text text-sm" ref={textRef}></text>
+    </g>
+  );
+};
+
+const NetworkNodes = ({ data }: NodesProps = { data: [] }) => {
+  return (
+    <g className="nodes">
+      {data?.length === 0 ? (
+        <g className="node"></g>
+      ) : (
+        data?.map((node: Node) => <NetworkNode key={node.id} data={node} />)
+      )}
+    </g>
+  );
+};
+
+export default NetworkNodes;

--- a/utils/chart.ts
+++ b/utils/chart.ts
@@ -1,0 +1,10 @@
+export const fillCircleByValue = (value: number) => {
+  if (value === 0) return '#7DE5F5D1';
+
+  if (value === 1) return '#89D3C7D1';
+
+  return '#31ACA9D1';
+};
+
+export const weighValueByMutiply = (value: number, mutiply = 30) =>
+  Math.abs(value - 3) * mutiply;


### PR DESCRIPTION
* 네트워크 그래프 컴포넌트에서 한번에 관리하던 노드와 링크들을 컴포넌트로 나누어 관리
* 네트워크 그래프를 그리는 계산 로직만 NetworkGraph에 존재하도록 변경